### PR TITLE
Specify error redirect for get git remote url

### DIFF
--- a/src/lighthaus.zsh-theme
+++ b/src/lighthaus.zsh-theme
@@ -59,9 +59,9 @@ lighthaus_git_prompt() {
     _GIT_SRC=""
 
     if [[ -n "$_BRANCH" ]]; then
-        if [[ $(git remote get-url origin | grep -m1 -o 'github') == "github" ]]; then
+        if [[ $(git remote get-url origin 2> /dev/null | grep -m1 -o 'github') == "github" ]]; then
            _GIT_SRC="%{$_PURPLE%} %{$_RESET%}"
-        elif [[ $(git remote get-url origin | grep -m1 -o 'gitlab') == "gitlab" ]]; then
+        elif [[ $(git remote get-url origin 2> /dev/null | grep -m1 -o 'gitlab') == "gitlab" ]]; then
             _GIT_SRC="%{$_PURPLE%} %{$_RESET%}"
         else
             _GIT_SRC=""


### PR DESCRIPTION
Hi!
First of all, thanks for a great theme!

Btw, I've noticed that errors are spammed when local git repo doesn't have any remote and that's kinda annoying, so here's a little fix for that problem.